### PR TITLE
Task: emit errors to outputStream

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -80,6 +80,8 @@ const StreamDownloader = (url: string, options: YTDLStreamOptions) => {
 
     const outputStream = output.pipe(opus);
 
+    output.on('error', e => outputStream.emit('error', e));
+
     for (const event of evn) {
         inputStream.on(event, (...args) => outputStream.emit(event, ...args));
     }


### PR DESCRIPTION
Hey there - a quick fix to (partially) address https://github.com/DevSnowflake/discord-ytdl-core/issues/20

Opened an issue in `prism-media` and touched base with Amish here: https://github.com/amishshah/prism-media/issues/67#issuecomment-803407427

Tested locally and while it doesn't stop the error being thrown, we can at least now catch it and not crash the process.

Might be some optimisations possible as well, as Amish has mentioned.